### PR TITLE
Switch to ESM

### DIFF
--- a/core/HafasFetcher.mjs
+++ b/core/HafasFetcher.mjs
@@ -1,8 +1,9 @@
 /* global config */
-const dayjs = require("dayjs");
-const isSameOrAfter = require("dayjs/plugin/isSameOrAfter");
-const Log = require("logger");
-const packageJson = require("../package.json");
+import Log from "../../../js/logger.js";
+import {createClient} from "hafas-client";
+import dayjs from "dayjs";
+import isSameOrAfter from "dayjs/plugin/isSameOrAfter.js";
+import packageJson from "../package.json" with { "type": "json" };
 
 dayjs.extend(isSameOrAfter);
 
@@ -16,7 +17,7 @@ function getArrayDiff (arrayA, arrayB) {
   return arrayA.filter((element) => !arrayB.includes(element));
 }
 
-module.exports = class HafasFetcher {
+export default class HafasFetcher {
   /**
    *
    * @param {object} config The configuration used for this fetcher. It has the following format:
@@ -39,7 +40,6 @@ module.exports = class HafasFetcher {
   }
 
   async init () {
-    const {createClient} = await import("hafas-client");
     const {profile} = await import(`hafas-client/p/${this.config.hafasProfile}/index.js`);
     this.hafasClient = createClient(
       profile,

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,6 +1,6 @@
 const NodeHelper = require("node_helper");
 const Log = require("logger");
-const HafasFetcher = require("./core/HafasFetcher");
+const HafasFetcher = require("./core/HafasFetcher.mjs").default;
 
 module.exports = NodeHelper.create({
   start () {


### PR DESCRIPTION
This is a draft PR to transform the module step by step from commonjs to esm.

`require(esm)` is supported since node 23. Since node 22 is a LTS version and is supported until 30 Apr 2027. We may not use this before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Transitioned to ES module syntax for improved compatibility and modern JavaScript standards.
  
- **Bug Fixes**
	- Ensured consistent functionality of the `HafasFetcher` and `NodeHelper` classes despite changes in import/export syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->